### PR TITLE
Allow PDUs slightly larger than 64KiB

### DIFF
--- a/smpp/pdu/body.go
+++ b/smpp/pdu/body.go
@@ -12,7 +12,8 @@ import (
 )
 
 // MaxSize is the maximum size allowed for a PDU.
-const MaxSize = 65535 // 64KiB
+// Any PDU header that tells it is longer will result in a read error.
+const MaxSize = 69632 // Somewhat above 64KiB
 
 // Body is an abstract Protocol Data Unit (PDU) interface
 // for manipulating PDUs.

--- a/smpp/pdu/header_test.go
+++ b/smpp/pdu/header_test.go
@@ -69,7 +69,7 @@ func TestDecodeHeaderShort(t *testing.T) {
 	}
 }
 
-func TestDecodeHeaderMax(t *testing.T) {
+func TestDecodeHeaderLenBelowMax(t *testing.T) {
 	bin := []byte{
 		0x00, 0x00, 0xFF, 0xFF, // 64KiB Len
 		0x00, 0x00, 0x00, 0x00,
@@ -83,10 +83,20 @@ func TestDecodeHeaderMax(t *testing.T) {
 	if h.Len != 65535 {
 		t.Fatalf("unexpected parsed header Len: %#v", h.Len)
 	}
+}
 
-	bin[1] = 0x01 // increase CMD length beyond our max
-	h, err = DecodeHeader(bytes.NewBuffer(bin))
+func TestDecodeHeaderLenAboveMax(t *testing.T) {
+	bin := []byte{
+		0x00, 0x01, 0x10, 0x01, // 69632 + 1 Len
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+	h, err := DecodeHeader(bytes.NewBuffer(bin))
 	if err == nil {
 		t.Fatalf("unexpected parsing of big Len: %#v", h)
+	}
+	if h != nil {
+		t.Fatalf("unexpected header returned:, %#v", h)
 	}
 }


### PR DESCRIPTION
In order to allow `message_payload` in `submit_sm` TLVs to be limited to 64KiB, we have to allow more than 64KiB to be read when reading from the socket.

This sets the limit sort of arbitrary at `69632`, which would allow PDUs greater than 64KiB to be read while still keeping a reasonable limit on PDUs.